### PR TITLE
Add monthly events calendar to index

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -9,7 +9,7 @@
  * compiled file so the styles you add here take precedence over styles defined in any other CSS/SCSS
  * files in this directory. Styles in this file should be added after the last require_* statement.
  * It is generally better to create a new file per style scope.
- *
+ *=require simple_calendar
  */
 
 // Custom bootstrap variables must be set or imported *before* bootstrap.

--- a/app/views/events/index.html.erb
+++ b/app/views/events/index.html.erb
@@ -2,6 +2,19 @@
 
 <h1>Events</h1>
 
+
+<div id="events-calendar">
+<%= month_calendar events: @events do |date, events| %>
+  <%=  date.strftime("%d %b") %>
+
+  <% events.each do |event| %>
+    <div>
+      <%= link_to event.title, event_path(event) %>
+    </div>
+  <% end %>
+<% end %>
+</div>
+
 <table>
   <thead>
     <tr>


### PR DESCRIPTION
## Changes Made
- Use simple_calendar method to generate a monthly calendar (html table) in events index
- Require simple_calendar in application.scss (we can remove and require per scope if we find that we won't use it elsewhere later on) 

