### PR TITLE
Fix event time break on updates

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -116,8 +116,7 @@ class EventsController < ApplicationController
       if @event.update(event_params)
         @event.start_time = parse_time_to_singapore(@event.start_time)
         @event.end_time = parse_time_to_singapore(@event.end_time)
-        @event.update(start_time: @event.start_time)
-        @event.update(end_time: @event.end_time)
+        @event.update(start_time: @event.start_time, end_time: @event.end_time)
         format.html { redirect_to @event, notice: 'Event was successfully updated.' }
         format.json { render :show, status: :ok, location: @event }
       else

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -116,7 +116,8 @@ class EventsController < ApplicationController
       if @event.update(event_params)
         @event.start_time = parse_time_to_singapore(@event.start_time)
         @event.end_time = parse_time_to_singapore(@event.end_time)
-        puts @event
+        @event.update(start_time: @event.start_time)
+        @event.update(end_time: @event.end_time)
         format.html { redirect_to @event, notice: 'Event was successfully updated.' }
         format.json { render :show, status: :ok, location: @event }
       else

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -104,7 +104,6 @@ class EventsController < ApplicationController
   # PATCH/PUT /events/1.json
   def update
     @types = Type.all
-    @event = parse_event_to_local_time(@event)
     if params[:event][:img_url] != ""
       uploaded_file = params[:event][:img_url].path
       cloudinary_file = Cloudinary::Uploader.upload(uploaded_file)
@@ -115,6 +114,9 @@ class EventsController < ApplicationController
 
     respond_to do |format|
       if @event.update(event_params)
+        @event.start_time = parse_time_to_singapore(@event.start_time)
+        @event.end_time = parse_time_to_singapore(@event.end_time)
+        puts @event
         format.html { redirect_to @event, notice: 'Event was successfully updated.' }
         format.json { render :show, status: :ok, location: @event }
       else


### PR DESCRIPTION
Using event_params will ignore anything you try to do with parse_time_to_singapore, so run a second update after that. It's janky and inefficient but at least it works.